### PR TITLE
Fix gradle build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,5 @@
+ossrhUsername=
+ossrhPassword=
+signing.keyId=
+signing.password=
+signing.secretKeyRingFile=


### PR DESCRIPTION
Build requires gradle properties to run build, although they are only needed for release.  
Adding file with empty properties solves build issue.