### PR TITLE
Add missing spring bean in sample project

### DIFF
--- a/samples/example/src/main/java/io/nixer/example/WebSecurityConfig.java
+++ b/samples/example/src/main/java/io/nixer/example/WebSecurityConfig.java
@@ -7,8 +7,6 @@ import io.nixer.nixerplugin.captcha.config.CaptchaConfigurer;
 import io.nixer.nixerplugin.captcha.security.CaptchaChecker;
 import io.nixer.nixerplugin.core.detection.filter.FilterConfiguration;
 import io.nixer.nixerplugin.core.detection.filter.behavior.Conditions;
-import io.nixer.nixerplugin.captcha.config.CaptchaConfigurer;
-import io.nixer.nixerplugin.captcha.security.CaptchaChecker;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.servlet.filter.OrderedRequestContextFilter;
 import org.springframework.context.annotation.Bean;
@@ -82,6 +80,11 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 //                .passwordEncoder(encoder)
 //                .withUser("user").password(encoder.encode("user")).roles("USER")
 //                .withObjectPostProcessor(new CaptchaConfigurer(captchaChecker));
+    }
+
+    @Bean
+    public RequestContextFilter requestContextFilter() {
+        return new OrderedRequestContextFilter();
     }
 
     /**

--- a/samples/example/src/main/java/io/nixer/example/WebSecurityConfig.java
+++ b/samples/example/src/main/java/io/nixer/example/WebSecurityConfig.java
@@ -82,6 +82,10 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 //                .withObjectPostProcessor(new CaptchaConfigurer(captchaChecker));
     }
 
+    /**
+     * Plugin needs access to HttpServletRequest, because of that we need this been to set RequestContextHolder and
+     * make it possible for spring to inject proxy for request.
+     */
     @Bean
     public RequestContextFilter requestContextFilter() {
         return new OrderedRequestContextFilter();


### PR DESCRIPTION
Missing spring bean provides request/response context so that spring bean could use Request/Response proxies. 