### PR TITLE
Fix error handling in metadata filters

### DIFF
--- a/captcha/nixer-plugin-captcha.gradle.kts
+++ b/captcha/nixer-plugin-captcha.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
     testImplementation("org.springframework", "spring-test")
     testImplementation("org.springframework.boot", "spring-boot-starter-web")
     testImplementation("org.springframework.boot", "spring-boot-starter-test") {
+        exclude(module = "junit-vintage-engine")
         exclude(module = "junit")
     }
     testImplementation("org.springframework.security", "spring-security-test")

--- a/core/nixer-plugin-core.gradle.kts
+++ b/core/nixer-plugin-core.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     testImplementation("org.springframework", "spring-test")
     testImplementation("org.springframework.boot", "spring-boot-starter-web")
     testImplementation("org.springframework.boot", "spring-boot-starter-test") {
+        exclude(module = "junit-vintage-engine")
         exclude(module = "junit")
     }
     testImplementation("org.springframework.security", "spring-security-test")

--- a/core/src/main/java/io/nixer/nixerplugin/core/detection/filter/MetadataFilter.java
+++ b/core/src/main/java/io/nixer/nixerplugin/core/detection/filter/MetadataFilter.java
@@ -6,6 +6,8 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -13,11 +15,17 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @Order(Ordered.HIGHEST_PRECEDENCE + 10)
 public abstract class MetadataFilter extends OncePerRequestFilter {
 
+    private final Log logger = LogFactory.getLog(getClass());
+
     protected abstract void apply(final HttpServletRequest request);
 
     @Override
     protected void doFilterInternal(final HttpServletRequest request, final HttpServletResponse response, final FilterChain filterChain) throws ServletException, IOException {
-        this.apply(request);
+        try {
+            this.apply(request);
+        } catch (Exception e) {
+            logger.error("Failed to execute filter", e);
+        }
         filterChain.doFilter(request, response);
     }
 }

--- a/core/src/main/java/io/nixer/nixerplugin/core/detection/filter/ip/IpMetadataFilter.java
+++ b/core/src/main/java/io/nixer/nixerplugin/core/detection/filter/ip/IpMetadataFilter.java
@@ -2,10 +2,7 @@ package io.nixer.nixerplugin.core.detection.filter.ip;
 
 import javax.servlet.http.HttpServletRequest;
 
-import io.nixer.nixerplugin.core.detection.filter.MetadataFilter;
-import io.nixer.nixerplugin.core.detection.filter.RequestMetadata;
-import io.nixer.nixerplugin.core.domain.ip.IpLookup;
-import io.nixer.nixerplugin.core.domain.ip.net.IpAddress;
+import com.google.common.net.InetAddresses;
 import io.nixer.nixerplugin.core.detection.filter.MetadataFilter;
 import io.nixer.nixerplugin.core.detection.filter.RequestMetadata;
 import io.nixer.nixerplugin.core.domain.ip.IpLookup;
@@ -30,6 +27,10 @@ public class IpMetadataFilter extends MetadataFilter {
     @Override
     protected void apply(final HttpServletRequest request) {
         final String ip = request.getRemoteAddr();
+        if (!InetAddresses.isInetAddress(ip)) {
+            // this case could happen if reverse proxy is inplace then x-forward headers could contain address that is not in IP format
+            return;
+        }
         final IpAddress address = ipLookup.lookup(ip);
 
         if (address != null) {

--- a/core/src/test/java/io/nixer/nixerplugin/core/detection/filter/MetadataFilterTest.java
+++ b/core/src/test/java/io/nixer/nixerplugin/core/detection/filter/MetadataFilterTest.java
@@ -1,0 +1,38 @@
+package io.nixer.nixerplugin.core.detection.filter;
+
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.verify;
+
+class MetadataFilterTest {
+
+    @Test
+    void shouldContinueFilterProcessingInChainOnException() throws IOException, ServletException {
+        MetadataFilter filter = new ExceptionThrowingFilter();
+
+        final MockHttpServletRequest request = new MockHttpServletRequest("GET", "/login");
+        final MockHttpServletResponse response = new MockHttpServletResponse();
+        final FilterChain filterChain = Mockito.mock(FilterChain.class);
+
+        assertDoesNotThrow(() -> filter.doFilter(request, response, filterChain));
+
+        verify(filterChain).doFilter(request, response);
+    }
+
+    private static class ExceptionThrowingFilter extends MetadataFilter {
+
+        @Override
+        protected void apply(final HttpServletRequest request) {
+            throw new RuntimeException();
+        }
+    }
+}

--- a/core/src/test/java/io/nixer/nixerplugin/core/detection/filter/ip/IpMetadataFilterTest.java
+++ b/core/src/test/java/io/nixer/nixerplugin/core/detection/filter/ip/IpMetadataFilterTest.java
@@ -64,6 +64,7 @@ class IpMetadataFilterTest {
 
         filter.apply(request);
 
+        assertNull(request.getAttribute(RequestMetadata.IP_METADATA));
         verifyZeroInteractions(ipLookup);
     }
 

--- a/core/src/test/java/io/nixer/nixerplugin/core/detection/filter/ip/IpMetadataFilterTest.java
+++ b/core/src/test/java/io/nixer/nixerplugin/core/detection/filter/ip/IpMetadataFilterTest.java
@@ -1,0 +1,70 @@
+package io.nixer.nixerplugin.core.detection.filter.ip;
+
+import io.nixer.nixerplugin.core.detection.filter.RequestMetadata;
+import io.nixer.nixerplugin.core.domain.ip.IpLookup;
+import io.nixer.nixerplugin.core.domain.ip.net.IpAddress;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class IpMetadataFilterTest {
+
+    private static final String IP = "1.2.3.4";
+    private static final String INVALID_IP = "example.com";
+
+    @Mock
+    private final IpLookup ipLookup = mock(IpLookup.class);
+
+    private IpMetadataFilter filter;
+    private MockHttpServletRequest request;
+
+    @BeforeEach
+    void setup() {
+        filter = new IpMetadataFilter(ipLookup);
+        request = new MockHttpServletRequest("GET", "/login");
+    }
+
+    @Test
+    void shouldSetIpMetadataOnRequest() {
+        when(ipLookup.lookup(IP))
+                .thenReturn(IpAddress.fromIp(IP));
+
+        request.setRemoteAddr(IP);
+
+        filter.apply(request);
+
+        assertEquals(new IpMetadata(true), request.getAttribute(RequestMetadata.IP_METADATA));
+    }
+
+    @Test
+    void shouldNotSetIpMetadataOnRequest() {
+        when(ipLookup.lookup(IP))
+                .thenReturn(null);
+
+        request.setRemoteAddr(IP);
+
+        filter.apply(request);
+
+        assertNull(request.getAttribute(RequestMetadata.IP_METADATA));
+    }
+
+    @Test
+    void shouldSkipIpLookupForInvalidIp() {
+        request.setRemoteAddr(INVALID_IP);
+
+        filter.apply(request);
+
+        verifyZeroInteractions(ipLookup);
+    }
+
+}

--- a/samples/example/nixer-plugin-example.gradle.kts
+++ b/samples/example/nixer-plugin-example.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     testImplementation("org.springframework.integration", "spring-integration-test")
     testImplementation("org.springframework.security", "spring-security-test")
     testImplementation("org.springframework.boot", "spring-boot-starter-test") {
+        exclude(module = "junit-vintage-engine")
         exclude(module = "junit")
     }
 }


### PR DESCRIPTION
Exception thrown in Metadata filter was breaking request processing. Now exceptions are captch and we are continuing processing filter chain.

This situation was happening when remoteAdd given in request was not valid IP. This could happen if x-forwarded headers are used. IpMetadataFilter was corrected to check for valid ip format before proceeding with ip lookup. This is to prevent costly exception from being thrown.

In addition I excluded junit-vintage-engine dependency from dependencies to prevent test build error from happening.
 