### PR TITLE
bugfix(rules): fix bean loading with username/useragent names

### DIFF
--- a/core/src/main/java/io/nixer/nixerplugin/core/detection/DetectionConfiguration.java
+++ b/core/src/main/java/io/nixer/nixerplugin/core/detection/DetectionConfiguration.java
@@ -90,7 +90,7 @@ public class DetectionConfiguration {
 
     @Configuration
     @ConditionalOnProperty(prefix = "nixer.rules.failed-login-threshold.username", name = "enabled", havingValue = "true")
-    static class UserAgentThresholdRule {
+    static class UsernameThresholdRule {
 
         @Autowired
         DetectionConfiguration detection;
@@ -110,19 +110,19 @@ public class DetectionConfiguration {
         }
 
         @Bean
-        public UserAgentFailedLoginOverThresholdFilter userAgentFilter() {
-            return new UserAgentFailedLoginOverThresholdFilter(userAgentRegistry());
+        public UsernameFailedLoginOverThresholdFilter usernameFilter() {
+            return new UsernameFailedLoginOverThresholdFilter(usernameRegistry());
         }
 
         @Bean
-        public UserAgentOverLoginThresholdRegistry userAgentRegistry() {
-            return new UserAgentOverLoginThresholdRegistry();
+        public UsernameOverLoginThresholdRegistry usernameRegistry() {
+            return new UsernameOverLoginThresholdRegistry();
         }
     }
 
     @Configuration
     @ConditionalOnProperty(prefix = "nixer.rules.failed-login-threshold.useragent", name = "enabled", havingValue = "true")
-    static class UsernameThresholdRule {
+    static class UserAgentThresholdRule {
 
         @Autowired
         DetectionConfiguration detection;
@@ -142,13 +142,13 @@ public class DetectionConfiguration {
         }
 
         @Bean
-        public UsernameFailedLoginOverThresholdFilter usernameFilter() {
-            return new UsernameFailedLoginOverThresholdFilter(usernameRegistry());
+        public UserAgentFailedLoginOverThresholdFilter userAgentFilter() {
+            return new UserAgentFailedLoginOverThresholdFilter(userAgentRegistry());
         }
 
         @Bean
-        public UsernameOverLoginThresholdRegistry usernameRegistry() {
-            return new UsernameOverLoginThresholdRegistry();
+        public UserAgentOverLoginThresholdRegistry userAgentRegistry() {
+            return new UserAgentOverLoginThresholdRegistry();
         }
     }
 

--- a/core/src/main/java/io/nixer/nixerplugin/core/detection/rules/LoginAnomalyRuleFactory.java
+++ b/core/src/main/java/io/nixer/nixerplugin/core/detection/rules/LoginAnomalyRuleFactory.java
@@ -3,22 +3,14 @@ package io.nixer.nixerplugin.core.detection.rules;
 import java.time.Duration;
 
 import io.nixer.nixerplugin.core.detection.rules.threshold.IpFailedLoginOverThresholdRule;
-import io.nixer.nixerplugin.core.detection.rules.threshold.UserAgentLoginOverThresholdRule;
+import io.nixer.nixerplugin.core.detection.rules.threshold.UserAgentFailedLoginOverThresholdRule;
 import io.nixer.nixerplugin.core.detection.rules.threshold.UsernameFailedLoginOverThresholdRule;
 import io.nixer.nixerplugin.core.login.inmemory.CounterRegistry;
 import io.nixer.nixerplugin.core.login.inmemory.CountingStrategies;
 import io.nixer.nixerplugin.core.login.inmemory.LoginCounter;
 import io.nixer.nixerplugin.core.login.inmemory.LoginCounterBuilder;
-import io.nixer.nixerplugin.core.login.inmemory.CounterRegistry;
-import io.nixer.nixerplugin.core.login.inmemory.CountingStrategies;
 import io.nixer.nixerplugin.core.login.inmemory.FeatureKey;
-import io.nixer.nixerplugin.core.login.inmemory.LoginCounter;
-import io.nixer.nixerplugin.core.login.inmemory.LoginCounterBuilder;
 import org.springframework.util.Assert;
-
-import static io.nixer.nixerplugin.core.login.inmemory.FeatureKey.Features.IP;
-import static io.nixer.nixerplugin.core.login.inmemory.FeatureKey.Features.USERNAME;
-import static io.nixer.nixerplugin.core.login.inmemory.FeatureKey.Features.USER_AGENT_TOKEN;
 
 public class LoginAnomalyRuleFactory {
 
@@ -44,14 +36,14 @@ public class LoginAnomalyRuleFactory {
         return rule;
     }
 
-    public UserAgentLoginOverThresholdRule createUserAgentRule(final Duration window, final Integer threshold) {
+    public UserAgentFailedLoginOverThresholdRule createUserAgentRule(final Duration window, final Integer threshold) {
         final LoginCounter counter = LoginCounterBuilder.counter(FeatureKey.Features.USER_AGENT_TOKEN)
                 .window(window)
                 .count(CountingStrategies.TOTAL_FAILS)
                 .build();
         counterRegistry.registerCounter(counter);
 
-        final UserAgentLoginOverThresholdRule rule = new UserAgentLoginOverThresholdRule(counter);
+        final UserAgentFailedLoginOverThresholdRule rule = new UserAgentFailedLoginOverThresholdRule(counter);
         if (threshold != null) {
             rule.setThreshold(threshold);
         }

--- a/core/src/main/java/io/nixer/nixerplugin/core/detection/rules/threshold/UserAgentFailedLoginOverThresholdRule.java
+++ b/core/src/main/java/io/nixer/nixerplugin/core/detection/rules/threshold/UserAgentFailedLoginOverThresholdRule.java
@@ -11,15 +11,15 @@ import io.nixer.nixerplugin.core.login.inmemory.LoginMetric;
 import org.springframework.util.Assert;
 
 /**
- * Rule that checks if number of login failures for useragent exceeds threshold and emits {@link IpFailedLoginOverThresholdEvent} event if it does.
+ * Rule that checks if number of login failures for useragent exceeds threshold and emits {@link UserAgentFailedLoginOverThresholdEvent} event if it does.
  */
-public class UserAgentLoginOverThresholdRule extends ThresholdAnomalyRule {
+public class UserAgentFailedLoginOverThresholdRule extends ThresholdAnomalyRule {
 
     private static final int THRESHOLD_VALUE = 10;
 
     private final LoginMetric failedLoginMetric;
 
-    public UserAgentLoginOverThresholdRule(final LoginMetric failedLoginMetric) {
+    public UserAgentFailedLoginOverThresholdRule(final LoginMetric failedLoginMetric) {
         super(THRESHOLD_VALUE);
         Assert.notNull(failedLoginMetric, "LoginMetric must not be null");
         this.failedLoginMetric = failedLoginMetric;

--- a/core/src/test/java/io/nixer/nixerplugin/core/detection/config/DetectionConfigurationTest.java
+++ b/core/src/test/java/io/nixer/nixerplugin/core/detection/config/DetectionConfigurationTest.java
@@ -1,6 +1,12 @@
 package io.nixer.nixerplugin.core.detection.config;
 
 import io.nixer.nixerplugin.core.detection.DetectionConfiguration;
+import io.nixer.nixerplugin.core.detection.filter.login.IpFailedLoginOverThresholdFilter;
+import io.nixer.nixerplugin.core.detection.filter.login.UserAgentFailedLoginOverThresholdFilter;
+import io.nixer.nixerplugin.core.detection.filter.login.UsernameFailedLoginOverThresholdFilter;
+import io.nixer.nixerplugin.core.detection.registry.IpOverLoginThresholdRegistry;
+import io.nixer.nixerplugin.core.detection.registry.UserAgentOverLoginThresholdRegistry;
+import io.nixer.nixerplugin.core.detection.registry.UsernameOverLoginThresholdRegistry;
 import io.nixer.nixerplugin.core.detection.rules.AnomalyRule;
 import io.nixer.nixerplugin.core.detection.rules.AnomalyRulesRunner;
 import io.nixer.nixerplugin.core.detection.rules.threshold.IpFailedLoginOverThresholdRule;
@@ -66,6 +72,55 @@ class DetectionConfigurationTest {
                     assertThat(context).hasSingleBean(UserAgentLoginOverThresholdRule.class);
                     assertThat(context).hasSingleBean(UsernameFailedLoginOverThresholdRule.class);
                     assertThat(context).getBeanNames(AnomalyRule.class).hasSize(3);
+                });
+    }
+
+    @Test
+    void shouldRegisterEnabledUsernameRules() {
+        contextRunner
+                .withPropertyValues(
+                        "nixer.rules.failed-login-threshold.username.enabled=true"
+                )
+                .withUserConfiguration(DetectionConfiguration.class)
+                .run(context -> {
+                    assertThat(context).hasSingleBean(AnomalyRulesRunner.class);
+                    assertThat(context).hasSingleBean(UsernameFailedLoginOverThresholdRule.class);
+                    assertThat(context).getBeanNames(AnomalyRule.class).hasSize(1);
+                    assertThat(context).hasSingleBean(UsernameFailedLoginOverThresholdFilter.class);
+                    assertThat(context).hasSingleBean(UsernameOverLoginThresholdRegistry.class);
+                });
+    }
+
+
+    @Test
+    void shouldRegisterEnabledUserAgentRules() {
+        contextRunner
+                .withPropertyValues(
+                        "nixer.rules.failed-login-threshold.useragent.enabled=true"
+                )
+                .withUserConfiguration(DetectionConfiguration.class)
+                .run(context -> {
+                    assertThat(context).hasSingleBean(AnomalyRulesRunner.class);
+                    assertThat(context).hasSingleBean(UserAgentLoginOverThresholdRule.class);
+                    assertThat(context).getBeanNames(AnomalyRule.class).hasSize(1);
+                    assertThat(context).hasSingleBean(UserAgentFailedLoginOverThresholdFilter.class);
+                    assertThat(context).hasSingleBean(UserAgentOverLoginThresholdRegistry.class);
+                });
+    }
+
+    @Test
+    void shouldRegisterEnabledIpRules() {
+        contextRunner
+                .withPropertyValues(
+                        "nixer.rules.failed-login-threshold.ip.enabled=true"
+                )
+                .withUserConfiguration(DetectionConfiguration.class)
+                .run(context -> {
+                    assertThat(context).hasSingleBean(AnomalyRulesRunner.class);
+                    assertThat(context).hasSingleBean(IpFailedLoginOverThresholdRule.class);
+                    assertThat(context).getBeanNames(AnomalyRule.class).hasSize(1);
+                    assertThat(context).hasSingleBean(IpFailedLoginOverThresholdFilter.class);
+                    assertThat(context).hasSingleBean(IpOverLoginThresholdRegistry.class);
                 });
     }
 

--- a/core/src/test/java/io/nixer/nixerplugin/core/detection/config/DetectionConfigurationTest.java
+++ b/core/src/test/java/io/nixer/nixerplugin/core/detection/config/DetectionConfigurationTest.java
@@ -10,15 +10,7 @@ import io.nixer.nixerplugin.core.detection.registry.UsernameOverLoginThresholdRe
 import io.nixer.nixerplugin.core.detection.rules.AnomalyRule;
 import io.nixer.nixerplugin.core.detection.rules.AnomalyRulesRunner;
 import io.nixer.nixerplugin.core.detection.rules.threshold.IpFailedLoginOverThresholdRule;
-import io.nixer.nixerplugin.core.detection.rules.threshold.UserAgentLoginOverThresholdRule;
-import io.nixer.nixerplugin.core.detection.rules.threshold.UsernameFailedLoginOverThresholdRule;
-import io.nixer.nixerplugin.core.login.inmemory.CounterRegistry;
-import io.nixer.nixerplugin.core.login.inmemory.InMemoryLoginActivityRepository;
-import io.nixer.nixerplugin.core.detection.DetectionConfiguration;
-import io.nixer.nixerplugin.core.detection.rules.AnomalyRule;
-import io.nixer.nixerplugin.core.detection.rules.AnomalyRulesRunner;
-import io.nixer.nixerplugin.core.detection.rules.threshold.IpFailedLoginOverThresholdRule;
-import io.nixer.nixerplugin.core.detection.rules.threshold.UserAgentLoginOverThresholdRule;
+import io.nixer.nixerplugin.core.detection.rules.threshold.UserAgentFailedLoginOverThresholdRule;
 import io.nixer.nixerplugin.core.detection.rules.threshold.UsernameFailedLoginOverThresholdRule;
 import io.nixer.nixerplugin.core.login.inmemory.CounterRegistry;
 import io.nixer.nixerplugin.core.login.inmemory.InMemoryLoginActivityRepository;
@@ -69,7 +61,7 @@ class DetectionConfigurationTest {
                 .run(context -> {
                     assertThat(context).hasSingleBean(AnomalyRulesRunner.class);
                     assertThat(context).hasSingleBean(IpFailedLoginOverThresholdRule.class);
-                    assertThat(context).hasSingleBean(UserAgentLoginOverThresholdRule.class);
+                    assertThat(context).hasSingleBean(UserAgentFailedLoginOverThresholdRule.class);
                     assertThat(context).hasSingleBean(UsernameFailedLoginOverThresholdRule.class);
                     assertThat(context).getBeanNames(AnomalyRule.class).hasSize(3);
                 });
@@ -101,7 +93,7 @@ class DetectionConfigurationTest {
                 .withUserConfiguration(DetectionConfiguration.class)
                 .run(context -> {
                     assertThat(context).hasSingleBean(AnomalyRulesRunner.class);
-                    assertThat(context).hasSingleBean(UserAgentLoginOverThresholdRule.class);
+                    assertThat(context).hasSingleBean(UserAgentFailedLoginOverThresholdRule.class);
                     assertThat(context).getBeanNames(AnomalyRule.class).hasSize(1);
                     assertThat(context).hasSingleBean(UserAgentFailedLoginOverThresholdFilter.class);
                     assertThat(context).hasSingleBean(UserAgentOverLoginThresholdRegistry.class);

--- a/core/src/test/java/io/nixer/nixerplugin/core/detection/rules/UserAgentFailedLoginOverThresholdRuleTest.java
+++ b/core/src/test/java/io/nixer/nixerplugin/core/detection/rules/UserAgentFailedLoginOverThresholdRuleTest.java
@@ -3,12 +3,8 @@ package io.nixer.nixerplugin.core.detection.rules;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.nixer.nixerplugin.core.detection.rules.threshold.UserAgentLoginOverThresholdRule;
+import io.nixer.nixerplugin.core.detection.rules.threshold.UserAgentFailedLoginOverThresholdRule;
 import io.nixer.nixerplugin.core.detection.events.UserAgentFailedLoginOverThresholdEvent;
-import io.nixer.nixerplugin.core.login.LoginContext;
-import io.nixer.nixerplugin.core.login.inmemory.LoginMetric;
-import io.nixer.nixerplugin.core.detection.events.UserAgentFailedLoginOverThresholdEvent;
-import io.nixer.nixerplugin.core.detection.rules.threshold.UserAgentLoginOverThresholdRule;
 import io.nixer.nixerplugin.core.login.LoginContext;
 import io.nixer.nixerplugin.core.login.inmemory.LoginMetric;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,13 +26,13 @@ class UserAgentFailedLoginOverThresholdRuleTest {
     @Mock
     private LoginMetric loginMetric;
 
-    private UserAgentLoginOverThresholdRule rule;
+    private UserAgentFailedLoginOverThresholdRule rule;
 
     private static final String UAS_TOKEN = "uas-token";
 
     @BeforeEach
     void setup() {
-        rule = new UserAgentLoginOverThresholdRule(loginMetric);
+        rule = new UserAgentFailedLoginOverThresholdRule(loginMetric);
         rule.setThreshold(THRESHOLD);
     }
 


### PR DESCRIPTION
Names username/useragent were mistaken in detection configuration resulting in beans mixup.