### PR TITLE
NML-60, bugfix: failed captcha visibility enhancement

### DIFF
--- a/captcha/src/main/java/io/nixer/nixerplugin/captcha/config/CaptchaConfiguration.java
+++ b/captcha/src/main/java/io/nixer/nixerplugin/captcha/config/CaptchaConfiguration.java
@@ -15,6 +15,7 @@ import io.nixer.nixerplugin.core.login.LoginFailureType;
 import io.nixer.nixerplugin.core.login.LoginFailureTypeRegistry;
 import org.springframework.boot.autoconfigure.AutoConfigureOrder;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -29,8 +30,8 @@ import org.springframework.context.annotation.Import;
 public class CaptchaConfiguration implements LoginFailureTypeRegistry.Contributor {
 
     @Bean
-    public CaptchaAuthenticationProvider captchaAuthenticationProvider() {
-        return new CaptchaAuthenticationProvider();
+    public CaptchaAuthenticationProvider captchaAuthenticationProvider(CaptchaChecker captchaChecker, ApplicationEventPublisher publisher) {
+        return new CaptchaAuthenticationProvider(captchaChecker, publisher);
     }
 
     @Bean

--- a/captcha/src/main/java/io/nixer/nixerplugin/captcha/config/CaptchaConfiguration.java
+++ b/captcha/src/main/java/io/nixer/nixerplugin/captcha/config/CaptchaConfiguration.java
@@ -4,20 +4,10 @@ import io.nixer.nixerplugin.captcha.CaptchaBehavior;
 import io.nixer.nixerplugin.captcha.CaptchaService;
 import io.nixer.nixerplugin.captcha.CaptchaServiceFactory;
 import io.nixer.nixerplugin.captcha.endpoint.CaptchaEndpoint;
-import io.nixer.nixerplugin.captcha.recaptcha.RecaptchaConfiguration;
-import io.nixer.nixerplugin.captcha.security.BadCaptchaException;
-import io.nixer.nixerplugin.captcha.security.CaptchaChecker;
-import io.nixer.nixerplugin.captcha.validation.CaptchaValidator;
-import io.nixer.nixerplugin.core.NixerAutoConfiguration;
-import io.nixer.nixerplugin.core.login.LoginFailureType;
-import io.nixer.nixerplugin.core.login.LoginFailureTypeRegistry;
-import io.nixer.nixerplugin.captcha.CaptchaBehavior;
-import io.nixer.nixerplugin.captcha.CaptchaService;
-import io.nixer.nixerplugin.captcha.CaptchaServiceFactory;
-import io.nixer.nixerplugin.captcha.endpoint.CaptchaEndpoint;
 import io.nixer.nixerplugin.captcha.metrics.CaptchaMetricsReporter;
 import io.nixer.nixerplugin.captcha.recaptcha.RecaptchaConfiguration;
 import io.nixer.nixerplugin.captcha.security.BadCaptchaException;
+import io.nixer.nixerplugin.captcha.security.CaptchaAuthenticationProvider;
 import io.nixer.nixerplugin.captcha.security.CaptchaChecker;
 import io.nixer.nixerplugin.captcha.validation.CaptchaValidator;
 import io.nixer.nixerplugin.core.NixerAutoConfiguration;
@@ -29,17 +19,19 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
-import static io.nixer.nixerplugin.captcha.metrics.CaptchaMetricsReporter.LOGIN_ACTION;
-
 /**
  * {@link org.springframework.boot.autoconfigure.EnableAutoConfiguration Auto-configuration} for Captcha.
- *
  */
 @Configuration
 @EnableConfigurationProperties(value = {LoginCaptchaProperties.class})
 @Import({RecaptchaConfiguration.class})
 @AutoConfigureOrder(NixerAutoConfiguration.ORDER + 1)
 public class CaptchaConfiguration implements LoginFailureTypeRegistry.Contributor {
+
+    @Bean
+    public CaptchaAuthenticationProvider captchaAuthenticationProvider() {
+        return new CaptchaAuthenticationProvider();
+    }
 
     @Bean
     public CaptchaEndpoint captchaEndpoint(CaptchaChecker captchaChecker) {

--- a/captcha/src/main/java/io/nixer/nixerplugin/captcha/config/CaptchaConfigurer.java
+++ b/captcha/src/main/java/io/nixer/nixerplugin/captcha/config/CaptchaConfigurer.java
@@ -1,12 +1,20 @@
 package io.nixer.nixerplugin.captcha.config;
 
+import io.nixer.nixerplugin.captcha.security.CaptchaAuthenticationProvider;
 import io.nixer.nixerplugin.captcha.security.CaptchaChecker;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.ObjectPostProcessor;
 import org.springframework.util.Assert;
 
 /**
- * This class is used to integrate {@link CaptchaChecker} into Spring Authentication flow.
+ * This class is used to integrate {@link CaptchaChecker} into Spring Authentication flow as a post processor.
+ * Example usage:
+ * <pre>{@code
+ *         authenticationManagerBuilder.
+ *            .jdbcAuthentication()
+ *            .withObjectPostProcessor(new CaptchaConfigurer(...));
+ * }</pre>
+ * Currently this solution is not used in favor of {@link CaptchaAuthenticationProvider}.
  */
 public class CaptchaConfigurer implements ObjectPostProcessor<DaoAuthenticationProvider> {
 

--- a/captcha/src/main/java/io/nixer/nixerplugin/captcha/events/FailedCaptchaAuthenticationEvent.java
+++ b/captcha/src/main/java/io/nixer/nixerplugin/captcha/events/FailedCaptchaAuthenticationEvent.java
@@ -1,0 +1,12 @@
+package io.nixer.nixerplugin.captcha.events;
+
+import org.springframework.security.authentication.event.AbstractAuthenticationFailureEvent;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+
+public class FailedCaptchaAuthenticationEvent extends AbstractAuthenticationFailureEvent {
+
+    public FailedCaptchaAuthenticationEvent(final Authentication authentication, final AuthenticationException exception) {
+        super(authentication, exception);
+    }
+}

--- a/captcha/src/main/java/io/nixer/nixerplugin/captcha/security/CaptchaAuthenticationProvider.java
+++ b/captcha/src/main/java/io/nixer/nixerplugin/captcha/security/CaptchaAuthenticationProvider.java
@@ -2,10 +2,6 @@ package io.nixer.nixerplugin.captcha.security;
 
 import io.nixer.nixerplugin.captcha.error.CaptchaException;
 import io.nixer.nixerplugin.captcha.events.FailedCaptchaAuthenticationEvent;
-import io.nixer.nixerplugin.captcha.security.BadCaptchaException;
-import io.nixer.nixerplugin.captcha.security.CaptchaAuthenticationStatusException;
-import io.nixer.nixerplugin.captcha.security.CaptchaChecker;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.authentication.AccountStatusException;
 import org.springframework.security.authentication.AuthenticationProvider;
@@ -13,23 +9,15 @@ import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.util.Assert;
 
 public class CaptchaAuthenticationProvider implements AuthenticationProvider {
 
-    private CaptchaChecker captchaChecker;
+    private final CaptchaChecker captchaChecker;
 
-    private ApplicationEventPublisher eventPublisher;
+    private final ApplicationEventPublisher eventPublisher;
 
-    @Autowired
-    public void setCaptchaChecker(final CaptchaChecker captchaChecker) {
-        Assert.notNull(captchaChecker, "CaptchaChecker must not be null");
+    public CaptchaAuthenticationProvider(final CaptchaChecker captchaChecker, final ApplicationEventPublisher eventPublisher) {
         this.captchaChecker = captchaChecker;
-    }
-
-    @Autowired
-    void setEventPublisher(final ApplicationEventPublisher eventPublisher) {
-        Assert.notNull(captchaChecker, "ApplicationEventPublisher must not be null");
         this.eventPublisher = eventPublisher;
     }
 
@@ -37,7 +25,7 @@ public class CaptchaAuthenticationProvider implements AuthenticationProvider {
      * This method has no authority to authenticate a request, therefore it should never return {@link Authentication} object.
      * It should return {@code null} when captcha is correct or does not need to be checked.
      * It should throw an {@link AccountStatusException} when captcha is incorrect.
-     *
+     * <p>
      * See {@link ProviderManager} for authentication loop details.
      *
      * @param authentication

--- a/captcha/src/main/java/io/nixer/nixerplugin/captcha/security/CaptchaAuthenticationProvider.java
+++ b/captcha/src/main/java/io/nixer/nixerplugin/captcha/security/CaptchaAuthenticationProvider.java
@@ -36,15 +36,15 @@ public class CaptchaAuthenticationProvider implements AuthenticationProvider {
     public Authentication authenticate(final Authentication authentication) throws AuthenticationException {
         try {
             captchaChecker.checkCaptcha();
-        } catch (CaptchaException e) {
+        } catch (CaptchaException captchaException) {
             authentication.setAuthenticated(false);
 
             final FailedCaptchaAuthenticationEvent event = new FailedCaptchaAuthenticationEvent(
                     authentication,
-                    new BadCaptchaException("invalid captcha", e));
+                    new BadCaptchaException("invalid captcha", captchaException));
             eventPublisher.publishEvent(event);
 
-            throw new CaptchaAuthenticationStatusException("invalid captcha");
+            throw new CaptchaAuthenticationStatusException("invalid captcha", captchaException);
         }
         return null;
     }

--- a/captcha/src/main/java/io/nixer/nixerplugin/captcha/security/CaptchaAuthenticationProvider.java
+++ b/captcha/src/main/java/io/nixer/nixerplugin/captcha/security/CaptchaAuthenticationProvider.java
@@ -1,0 +1,68 @@
+package io.nixer.nixerplugin.captcha.security;
+
+import io.nixer.nixerplugin.captcha.error.CaptchaException;
+import io.nixer.nixerplugin.captcha.events.FailedCaptchaAuthenticationEvent;
+import io.nixer.nixerplugin.captcha.security.BadCaptchaException;
+import io.nixer.nixerplugin.captcha.security.CaptchaAuthenticationStatusException;
+import io.nixer.nixerplugin.captcha.security.CaptchaChecker;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.authentication.AccountStatusException;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.util.Assert;
+
+public class CaptchaAuthenticationProvider implements AuthenticationProvider {
+
+    private CaptchaChecker captchaChecker;
+
+    private ApplicationEventPublisher eventPublisher;
+
+    @Autowired
+    public void setCaptchaChecker(final CaptchaChecker captchaChecker) {
+        Assert.notNull(captchaChecker, "CaptchaChecker must not be null");
+        this.captchaChecker = captchaChecker;
+    }
+
+    @Autowired
+    void setEventPublisher(final ApplicationEventPublisher eventPublisher) {
+        Assert.notNull(captchaChecker, "ApplicationEventPublisher must not be null");
+        this.eventPublisher = eventPublisher;
+    }
+
+    /**
+     * This method has no authority to authenticate a request, therefore it should never return {@link Authentication} object.
+     * It should return {@code null} when captcha is correct or does not need to be checked.
+     * It should throw an {@link AccountStatusException} when captcha is incorrect.
+     *
+     * See {@link ProviderManager} for authentication loop details.
+     *
+     * @param authentication
+     * @return null when captcha is correct
+     * @throws AuthenticationException
+     */
+    @Override
+    public Authentication authenticate(final Authentication authentication) throws AuthenticationException {
+        try {
+            captchaChecker.checkCaptcha();
+        } catch (CaptchaException e) {
+            authentication.setAuthenticated(false);
+
+            final FailedCaptchaAuthenticationEvent event = new FailedCaptchaAuthenticationEvent(
+                    authentication,
+                    new BadCaptchaException("invalid captcha", e));
+            eventPublisher.publishEvent(event);
+
+            throw new CaptchaAuthenticationStatusException("invalid captcha");
+        }
+        return null;
+    }
+
+    @Override
+    public boolean supports(final Class<?> authentication) {
+        return UsernamePasswordAuthenticationToken.class.equals(authentication);
+    }
+}

--- a/captcha/src/main/java/io/nixer/nixerplugin/captcha/security/CaptchaAuthenticationStatusException.java
+++ b/captcha/src/main/java/io/nixer/nixerplugin/captcha/security/CaptchaAuthenticationStatusException.java
@@ -5,6 +5,7 @@ import org.springframework.security.authentication.ProviderManager;
 
 /**
  * Used to break authentication loop in Spring Security {@link ProviderManager} mechanism when captcha is invalid.
+ * This exception does not signalize anything about account status, it's purpose it to break authentication loop due to failed captcha.
  */
 public class CaptchaAuthenticationStatusException extends AccountStatusException {
 

--- a/captcha/src/main/java/io/nixer/nixerplugin/captcha/security/CaptchaAuthenticationStatusException.java
+++ b/captcha/src/main/java/io/nixer/nixerplugin/captcha/security/CaptchaAuthenticationStatusException.java
@@ -1,0 +1,18 @@
+package io.nixer.nixerplugin.captcha.security;
+
+import org.springframework.security.authentication.AccountStatusException;
+import org.springframework.security.authentication.ProviderManager;
+
+/**
+ * Used to break authentication loop in Spring Security {@link ProviderManager} mechanism when captcha is invalid.
+ */
+public class CaptchaAuthenticationStatusException extends AccountStatusException {
+
+    public CaptchaAuthenticationStatusException(final String msg, final Throwable t) {
+        super(msg, t);
+    }
+
+    public CaptchaAuthenticationStatusException(final String msg) {
+        super(msg);
+    }
+}

--- a/captcha/src/test/java/io/nixer/nixerplugin/captcha/config/CaptchaConfigurationTest.java
+++ b/captcha/src/test/java/io/nixer/nixerplugin/captcha/config/CaptchaConfigurationTest.java
@@ -5,15 +5,11 @@ import javax.servlet.http.HttpServletRequest;
 import io.nixer.nixerplugin.captcha.endpoint.CaptchaEndpoint;
 import io.nixer.nixerplugin.captcha.recaptcha.RecaptchaClient;
 import io.nixer.nixerplugin.captcha.recaptcha.RecaptchaV2ServiceFactory;
+import io.nixer.nixerplugin.captcha.security.CaptchaAuthenticationProvider;
 import io.nixer.nixerplugin.captcha.security.CaptchaChecker;
 import io.nixer.nixerplugin.captcha.validation.CaptchaValidator;
 import io.nixer.nixerplugin.core.login.LoginFailureTypeRegistry;
 import io.nixer.nixerplugin.core.metrics.MetricsFactory;
-import io.nixer.nixerplugin.captcha.endpoint.CaptchaEndpoint;
-import io.nixer.nixerplugin.captcha.recaptcha.RecaptchaClient;
-import io.nixer.nixerplugin.captcha.recaptcha.RecaptchaV2ServiceFactory;
-import io.nixer.nixerplugin.captcha.security.CaptchaChecker;
-import io.nixer.nixerplugin.captcha.validation.CaptchaValidator;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
@@ -59,6 +55,7 @@ class CaptchaConfigurationTest {
                 )
                 .run(context -> {
                     assertThat(context)
+                            .hasSingleBean(CaptchaAuthenticationProvider.class)
                             .hasSingleBean(CaptchaChecker.class)
                             .hasSingleBean(CaptchaValidator.class)
                             .hasSingleBean(CaptchaEndpoint.class)

--- a/captcha/src/test/java/io/nixer/nixerplugin/captcha/security/CaptchaAuthenticationProviderTest.java
+++ b/captcha/src/test/java/io/nixer/nixerplugin/captcha/security/CaptchaAuthenticationProviderTest.java
@@ -37,9 +37,7 @@ class CaptchaAuthenticationProviderTest {
 
     @BeforeEach
     void setUp() {
-        captchaAuthentication = new CaptchaAuthenticationProvider();
-        captchaAuthentication.setCaptchaChecker(captchaChecker);
-        captchaAuthentication.setEventPublisher(eventPublisher);
+        captchaAuthentication = new CaptchaAuthenticationProvider(captchaChecker, eventPublisher);
     }
 
     @Test

--- a/captcha/src/test/java/io/nixer/nixerplugin/captcha/security/CaptchaAuthenticationProviderTest.java
+++ b/captcha/src/test/java/io/nixer/nixerplugin/captcha/security/CaptchaAuthenticationProviderTest.java
@@ -31,33 +31,33 @@ class CaptchaAuthenticationProviderTest {
     @Mock
     private ApplicationEventPublisher eventPublisher;
 
-    private AbstractAuthenticationToken authentication;
+    private AbstractAuthenticationToken authenticationToken;
 
-    private CaptchaAuthenticationProvider captchaAuthentication;
+    private CaptchaAuthenticationProvider captchaAuthenticationProvider;
 
     @BeforeEach
     void setUp() {
-        captchaAuthentication = new CaptchaAuthenticationProvider(captchaChecker, eventPublisher);
+        captchaAuthenticationProvider = new CaptchaAuthenticationProvider(captchaChecker, eventPublisher);
     }
 
     @Test
     void captchaInvalid() {
-        authentication = new UsernamePasswordAuthenticationToken(
+        authenticationToken = new UsernamePasswordAuthenticationToken(
                 new Object(),
                 new Object(),
                 Collections.singletonList((GrantedAuthority) () -> "test"));
         doThrow(new CaptchaClientException("")).when(captchaChecker).checkCaptcha();
 
 
-        assertThrows(CaptchaAuthenticationStatusException.class, () -> captchaAuthentication.authenticate(authentication));
-        assertThat(authentication.isAuthenticated()).isFalse();
+        assertThrows(CaptchaAuthenticationStatusException.class, () -> captchaAuthenticationProvider.authenticate(authenticationToken));
+        assertThat(authenticationToken.isAuthenticated()).isFalse();
         verify(eventPublisher).publishEvent(any(FailedCaptchaAuthenticationEvent.class));
     }
 
 
     @Test
     void noCaptchaOrCaptchaCorrect() {
-        final Authentication result = captchaAuthentication.authenticate(authentication);
+        final Authentication result = captchaAuthenticationProvider.authenticate(authenticationToken);
 
         assertNull(result);
     }

--- a/captcha/src/test/java/io/nixer/nixerplugin/captcha/security/CaptchaAuthenticationProviderTest.java
+++ b/captcha/src/test/java/io/nixer/nixerplugin/captcha/security/CaptchaAuthenticationProviderTest.java
@@ -1,0 +1,66 @@
+package io.nixer.nixerplugin.captcha.security;
+
+import java.util.Collections;
+
+import io.nixer.nixerplugin.captcha.error.CaptchaClientException;
+import io.nixer.nixerplugin.captcha.events.FailedCaptchaAuthenticationEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class CaptchaAuthenticationProviderTest {
+
+    @Mock
+    private CaptchaChecker captchaChecker;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    private AbstractAuthenticationToken authentication;
+
+    private CaptchaAuthenticationProvider captchaAuthentication;
+
+    @BeforeEach
+    void setUp() {
+        captchaAuthentication = new CaptchaAuthenticationProvider();
+        captchaAuthentication.setCaptchaChecker(captchaChecker);
+        captchaAuthentication.setEventPublisher(eventPublisher);
+    }
+
+    @Test
+    void captchaInvalid() {
+        authentication = new UsernamePasswordAuthenticationToken(
+                new Object(),
+                new Object(),
+                Collections.singletonList((GrantedAuthority) () -> "test"));
+        doThrow(new CaptchaClientException("")).when(captchaChecker).checkCaptcha();
+
+
+        assertThrows(CaptchaAuthenticationStatusException.class, () -> captchaAuthentication.authenticate(authentication));
+        assertThat(authentication.isAuthenticated()).isFalse();
+        verify(eventPublisher).publishEvent(any(FailedCaptchaAuthenticationEvent.class));
+    }
+
+
+    @Test
+    void noCaptchaOrCaptchaCorrect() {
+        final Authentication result = captchaAuthentication.authenticate(authentication);
+
+        assertNull(result);
+    }
+}

--- a/captcha/src/test/java/io/nixer/nixerplugin/captcha/security/CaptchaCheckerTest.java
+++ b/captcha/src/test/java/io/nixer/nixerplugin/captcha/security/CaptchaCheckerTest.java
@@ -1,6 +1,7 @@
 package io.nixer.nixerplugin.captcha.security;
 
 import io.nixer.nixerplugin.captcha.CaptchaService;
+import io.nixer.nixerplugin.captcha.error.CaptchaException;
 import io.nixer.nixerplugin.captcha.error.CaptchaServiceException;
 import org.junit.jupiter.api.Test;
 import org.mockito.BDDMockito;
@@ -44,6 +45,7 @@ class CaptchaCheckerTest {
                 .when(captchaService).verifyResponse("captcha");
 
         assertThrows(BadCaptchaException.class, () -> captchaChecker.check(ANY));
+        assertThrows(CaptchaException.class, () -> captchaChecker.checkCaptcha());
     }
 
     @Test


### PR DESCRIPTION
The system sometimes does not report about failed captcha. 
Reproduction:
1. The system already displays captcha because of some rule with that behavior being active
2. Enter correct credentials and empty captcha
3. LoginActivityListener will not be fired