### PR TITLE
NML-4 Automate release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Get tag name and version # Transforms 'refs/tags/v1.0' into 'v1.0' as name and '1.0' version.
+      - name: Get tag name and version # Transforms 'refs/tags/v1.0' into 'v1.0' as name and '1.0' as version.
         id: get_tag_info
         run: |
           echo ::set-output name=NAME::${GITHUB_REF/refs\/tags\//}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: Create Releasae
+
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get tag name
+        id: get_tag
+        run: echo ::set-output name=NAME::${GITHUB_REF/refs\/tags\//}
+
+      - name: Checkout code # This already switches to the tag invoking the workflow.
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Build with Gradle
+        run: ./gradlew build
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.get_tag.outputs.NAME }}
+          release_name: ${{ steps.get_tag.outputs.NAME }}
+          body: Nixer Spring Plugin - release ${{ steps.get_tag.outputs.NAME }}
+          draft: true
+          prerelease: false
+
+      - name: Upload bloom-tool asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./bloom-tool/build/distributions/bloom-tool-${{ steps.get_tag.outputs.NAME }}.zip
+          asset_name: bloom-tool-${{ steps.get_tag.outputs.NAME }}.zip
+          asset_content_type: application/zip
+
+      - name: Upload ip_cloud_ranges asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./build/distributions/ip_cloud_ranges.zip
+          asset_name: ip_cloud_ranges.zip
+          asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Get tag name
-        id: get_tag
-        run: echo ::set-output name=NAME::${GITHUB_REF/refs\/tags\//}
+      - name: Get tag name and version # Transforms 'refs/tags/v1.0' into 'v1.0' as name and '1.0' version.
+        id: get_tag_info
+        run: |
+          echo ::set-output name=NAME::${GITHUB_REF/refs\/tags\//}
+          echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v/}
 
       - name: Checkout code # This already switches to the tag invoking the workflow.
         uses: actions/checkout@v2
@@ -32,9 +34,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ steps.get_tag.outputs.NAME }}
-          release_name: ${{ steps.get_tag.outputs.NAME }}
-          body: Nixer Spring Plugin - release ${{ steps.get_tag.outputs.NAME }}
+          tag_name: ${{ steps.get_tag_info.outputs.NAME }}
+          release_name: ${{ steps.get_tag_info.outputs.NAME }}
+          body: Nixer Spring Plugin - release ${{ steps.get_tag_info.outputs.NAME }}
           draft: true
           prerelease: false
 
@@ -44,8 +46,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./bloom-tool/build/distributions/bloom-tool-${{ steps.get_tag.outputs.NAME }}.zip
-          asset_name: bloom-tool-${{ steps.get_tag.outputs.NAME }}.zip
+          asset_path: ./bloom-tool/build/distributions/bloom-tool-${{ steps.get_tag_info.outputs.VERSION }}.zip
+          asset_name: bloom-tool-${{ steps.get_tag_info.outputs.VERSION }}.zip
           asset_content_type: application/zip
 
       - name: Upload ip_cloud_ranges asset

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 import io.spring.gradle.dependencymanagement.dsl.DependencyManagementExtension
 
 plugins {
+    distribution
     java
     id("io.spring.dependency-management") version "1.0.8.RELEASE" apply false
 }
@@ -150,6 +151,17 @@ configure(subprojects.filter {
         configure<JavaPluginConvention> {
             sourceCompatibility = JavaVersion.VERSION_1_8
             targetCompatibility = JavaVersion.VERSION_1_8
+        }
+    }
+}
+
+distributions {
+    create("cloudIpRanges") {
+        // Create package to be attached as GitHub release asset.
+        distributionBaseName.set("ip_cloud_ranges") // The release.yml workflow depends on this name.
+        version = "" // suppressed for now as the script version (showed by --version option) is not aligned yet
+        contents {
+            from("scripts/ip_cloud_ranges")
         }
     }
 }


### PR DESCRIPTION
Bases on pushing a tag with name matching the pattern `v*`.

Paths to the uploaded assets are partially hardcoded in the workflow, but since there are only two of them it's good enough for now. The workflow fails-fast in case the paths do not match.

Tested on the fork repo:
https://github.com/gcwiak/nixer-spring-plugin/actions/runs/55116436

It creates a draft release, so you won't see anything in the fork repo releases. Here is a screenshot from testing (versions are of course dummy):

![image](https://user-images.githubusercontent.com/9904686/76637319-ce384180-654a-11ea-96ee-f6c66d09f78c.png)



