### PR TITLE
NML-64 Remove LoginResult argument from the login activity storage API

### DIFF
--- a/core/src/main/java/io/nixer/nixerplugin/core/login/LoginActivityRepository.java
+++ b/core/src/main/java/io/nixer/nixerplugin/core/login/LoginActivityRepository.java
@@ -5,5 +5,5 @@ package io.nixer.nixerplugin.core.login;
  */
 public interface LoginActivityRepository {
 
-    void save(final LoginResult result, final LoginContext context);
+    void save(final LoginContext context);
 }

--- a/core/src/main/java/io/nixer/nixerplugin/core/login/LoginActivityService.java
+++ b/core/src/main/java/io/nixer/nixerplugin/core/login/LoginActivityService.java
@@ -22,7 +22,7 @@ public class LoginActivityService implements LoginActivityHandler {
     @Override
     public void handle(final LoginContext context) {
         for (LoginActivityRepository repository : repositories) {
-            repository.save(context.getLoginResult(), context);
+            repository.save(context);
         }
 
         rulesRunner.onLogin(context);

--- a/core/src/main/java/io/nixer/nixerplugin/core/login/inmemory/InMemoryLoginActivityRepository.java
+++ b/core/src/main/java/io/nixer/nixerplugin/core/login/inmemory/InMemoryLoginActivityRepository.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import io.nixer.nixerplugin.core.login.LoginActivityRepository;
 import io.nixer.nixerplugin.core.login.LoginContext;
-import io.nixer.nixerplugin.core.login.LoginResult;
 
 /**
  * Stores login results in memory.
@@ -15,8 +14,8 @@ public class InMemoryLoginActivityRepository implements LoginActivityRepository,
     private final List<LoginCounter> counters = new ArrayList<>();
 
     @Override
-    public void save(final LoginResult result, final LoginContext context) {
-        counters.forEach(counter -> counter.onLogin(result, context));
+    public void save(final LoginContext context) {
+        counters.forEach(counter -> counter.onLogin(context));
     }
 
     @Override

--- a/core/src/main/java/io/nixer/nixerplugin/core/login/inmemory/LoginCounter.java
+++ b/core/src/main/java/io/nixer/nixerplugin/core/login/inmemory/LoginCounter.java
@@ -1,7 +1,6 @@
 package io.nixer.nixerplugin.core.login.inmemory;
 
 import io.nixer.nixerplugin.core.login.LoginContext;
-import io.nixer.nixerplugin.core.login.LoginResult;
 import org.springframework.util.Assert;
 
 /**
@@ -30,10 +29,10 @@ public class LoginCounter implements LoginMetric {
         return key != null ? counter.count(key) : 0;
     }
 
-    public void onLogin(final LoginResult result, final LoginContext context) {
+    public void onLogin(final LoginContext context) {
         final String key = this.featureKey.key(context);
         if (key != null) {
-            countingStrategy.counter(counter, result).accept(key);
+            countingStrategy.counter(counter, context.getLoginResult()).accept(key);
         }
     }
 }

--- a/core/src/main/java/io/nixer/nixerplugin/core/login/metrics/LoginMetricsReporter.java
+++ b/core/src/main/java/io/nixer/nixerplugin/core/login/metrics/LoginMetricsReporter.java
@@ -6,13 +6,8 @@ import java.util.stream.Collectors;
 import io.nixer.nixerplugin.core.login.LoginActivityRepository;
 import io.nixer.nixerplugin.core.login.LoginContext;
 import io.nixer.nixerplugin.core.login.LoginFailureType;
-import io.nixer.nixerplugin.core.login.LoginResult;
 import io.nixer.nixerplugin.core.metrics.MetricsCounter;
 import io.nixer.nixerplugin.core.metrics.MetricsFactory;
-import io.nixer.nixerplugin.core.login.LoginActivityRepository;
-import io.nixer.nixerplugin.core.login.LoginContext;
-import io.nixer.nixerplugin.core.login.LoginFailureType;
-import io.nixer.nixerplugin.core.login.LoginResult;
 import org.springframework.util.Assert;
 
 import static io.nixer.nixerplugin.core.login.metrics.LoginCounters.LOGIN_SUCCESS;
@@ -47,8 +42,9 @@ public class LoginMetricsReporter implements LoginActivityRepository {
     }
 
     @Override
-    public void save(final LoginResult loginResult, final LoginContext loginContext) {
-        loginResult
+    public void save(final LoginContext loginContext) {
+        loginContext
+                .getLoginResult()
                 .onSuccess(it -> reportLoginSuccess())
                 .onFailure(result -> reportLoginFail(result.getFailureType()));
     }

--- a/core/src/test/java/io/nixer/nixerplugin/core/login/inmemory/LoginMetricCounterTest.java
+++ b/core/src/test/java/io/nixer/nixerplugin/core/login/inmemory/LoginMetricCounterTest.java
@@ -23,7 +23,7 @@ class LoginCounterTest {
 
     @Test
     void should_increment_counter() {
-        counter.onLogin(LoginResult.failure(LoginFailureType.BAD_PASSWORD), ipContext(IP_1));
+        counter.onLogin(failedLoginContext(IP_1));
 
         final int count = counter.value(IP_1);
 
@@ -39,9 +39,9 @@ class LoginCounterTest {
 
     @Test
     void should_track_multiple_keys() {
-        counter.onLogin(LoginResult.failure(LoginFailureType.BAD_PASSWORD), ipContext(IP_1));
-        counter.onLogin(LoginResult.failure(LoginFailureType.BAD_PASSWORD), ipContext(IP_2));
-        counter.onLogin(LoginResult.failure(LoginFailureType.BAD_PASSWORD), ipContext(IP_2));
+        counter.onLogin(failedLoginContext(IP_1));
+        counter.onLogin(failedLoginContext(IP_2));
+        counter.onLogin(failedLoginContext(IP_2));
 
         assertEquals(1, counter.value(IP_1));
         assertEquals(2, counter.value(IP_2));
@@ -49,8 +49,8 @@ class LoginCounterTest {
 
     @Test
     void should_reset_counter_on_successful_login() {
-        counter.onLogin(LoginResult.failure(LoginFailureType.BAD_PASSWORD), ipContext(IP_1));
-        counter.onLogin(LoginResult.success(), ipContext(IP_1));
+        counter.onLogin(failedLoginContext(IP_1));
+        counter.onLogin(successfulLoginContext(IP_1));
 
         final int count = counter.value(IP_1);
 
@@ -59,7 +59,7 @@ class LoginCounterTest {
 
     @Test
     void should_discard_count_after_expiration() {
-        counter.onLogin(LoginResult.failure(LoginFailureType.BAD_PASSWORD), ipContext(IP_1));
+        counter.onLogin(failedLoginContext(IP_1));
 
         clock.tick(Duration.ofMinutes(5));
 
@@ -68,11 +68,17 @@ class LoginCounterTest {
         assertEquals(0, count);
     }
 
-
-    private LoginContext ipContext(final String ip) {
+    private static LoginContext failedLoginContext(final String ip) {
         final LoginContext loginContext = new LoginContext();
         loginContext.setIpAddress(ip);
+        loginContext.setLoginResult(LoginResult.failure(LoginFailureType.BAD_PASSWORD));
         return loginContext;
     }
 
+    private static LoginContext successfulLoginContext(final String ip) {
+        final LoginContext loginContext = new LoginContext();
+        loginContext.setIpAddress(ip);
+        loginContext.setLoginResult(LoginResult.success());
+        return loginContext;
+    }
 }


### PR DESCRIPTION
NML-64 Remove LoginResult argument from the login activity storage API as it was already included in the LoginContext argument (exactly the same instance of LoginResult).